### PR TITLE
[codex] Add OpenAI feed summaries

### DIFF
--- a/client/src/main/scala/client/SettingsPage.scala
+++ b/client/src/main/scala/client/SettingsPage.scala
@@ -147,6 +147,48 @@ object SettingsPage {
                         formBlockStyle,
                         marginBottom.px := 16,
                         Label(
+                            "AI Provider",
+                            _.forId := "summary-provider-cmb",
+                            _.showColon := true,
+                            _.wrappingType := WrappingType.None,
+                            paddingRight.px := 20
+                        ),
+                        Select(
+                            _.id := "summary-provider-cmb",
+                            _.events.onChange
+                                .map(_.detail.selectedOption.textContent) --> settingsVar
+                                .updater[String]((a, b) =>
+                                    SummaryProvider.fromString(b) match
+                                        case Some(provider) =>
+                                            a.map(
+                                                _.copy(
+                                                    summaryProvider = Some(provider.displayName),
+                                                    summaryModel = Some(
+                                                        SummaryModel
+                                                            .defaultFor(provider)
+                                                            .displayName
+                                                    )
+                                                )
+                                            )
+                                        case None => a
+                                ),
+                            SummaryProvider.all.map(provider =>
+                                Select.option(
+                                    _.selected <-- settingsSignal.map { settings =>
+                                        settings
+                                            .flatMap(_.summaryProvider)
+                                            .flatMap(SummaryProvider.fromString)
+                                            .getOrElse(SummaryProvider.default) == provider
+                                    },
+                                    provider.displayName
+                                )
+                            )
+                        )
+                    ),
+                    div(
+                        formBlockStyle,
+                        marginBottom.px := 16,
+                        Label(
                             "AI Model",
                             _.forId := "summary-model-cmb",
                             _.showColon := true,
@@ -160,14 +202,25 @@ object SettingsPage {
                                 .updater[String]((a, b) =>
                                     a.map(x => x.copy(summaryModel = Some(b)))
                                 ),
-                            SummaryModel.all.map(model =>
-                                Select.option(
-                                    _.selected <-- settingsSignal.map(x =>
-                                        x.flatMap(_.summaryModel).contains(model.displayName)
-                                    ),
-                                    model.displayName
-                                )
-                            )
+                            children <-- settingsSignal.map { settings =>
+                                val provider = settings
+                                    .flatMap(_.summaryProvider)
+                                    .flatMap(SummaryProvider.fromString)
+                                    .getOrElse(SummaryProvider.default)
+                                val selectedModel = settings
+                                    .flatMap(_.summaryModel)
+                                    .flatMap(SummaryModel.fromString(provider, _))
+                                    .getOrElse(SummaryModel.defaultFor(provider))
+
+                                SummaryModel
+                                    .allFor(provider)
+                                    .map(model =>
+                                        Select.option(
+                                            _.selected := (selectedModel == model),
+                                            model.displayName
+                                        )
+                                    )
+                            }
                         )
                     ),
                     div(

--- a/server/src/main/resources/META-INF/native-image/ru.trett.rss/server/reflect-config.json
+++ b/server/src/main/resources/META-INF/native-image/ru.trett.rss/server/reflect-config.json
@@ -359,6 +359,10 @@
   "fields":[{"name":"derived$ConfigReader$lzy6"}]
 },
 {
+  "name":"ru.trett.rss.server.config.OpenAiConfig$",
+  "fields":[{"name":"derived$ConfigReader$lzy9"}]
+},
+{
   "name":"ru.trett.rss.server.config.JobConfig$",
   "fields":[{"name":"derived$ConfigReader$lzy7"}]
 },

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -34,6 +34,13 @@ google {
   api-key = ${?GOOGLE_API_KEY}
 }
 
+openai {
+  api-key = ""
+  api-key = ${?OPENAI_API_KEY}
+  default-model = "gpt-5-mini"
+  default-model = ${?OPENAI_MODEL}
+}
+
 jobs {
   token = ""
   token = ${?JOB_TOKEN}

--- a/server/src/main/scala/ru/trett/rss/server/Server.scala
+++ b/server/src/main/scala/ru/trett/rss/server/Server.scala
@@ -88,7 +88,9 @@ object Server extends IOApp:
                     summarizeService = new SummarizeService(
                         feedRepository,
                         client,
-                        appConfig.google.apiKey
+                        appConfig.google.apiKey,
+                        appConfig.openai.apiKey,
+                        appConfig.openai.defaultModel
                     )
                     channelService = ChannelService(channelRepository, client)
                     authFilter <- AuthFilter[IO]

--- a/server/src/main/scala/ru/trett/rss/server/config/AppConfig.scala
+++ b/server/src/main/scala/ru/trett/rss/server/config/AppConfig.scala
@@ -10,6 +10,7 @@ case class AppConfig(
     oauth: OAuthConfig,
     cors: CorsConfig,
     google: GoogleConfig,
+    openai: OpenAiConfig,
     jobs: JobConfig,
     jwt: JwtConfig
 ) derives ConfigReader
@@ -26,6 +27,8 @@ case class CorsConfig(allowedOrigin: String, allowCredentials: Boolean, maxAge: 
     derives ConfigReader
 
 case class GoogleConfig(apiKey: String) derives ConfigReader
+
+case class OpenAiConfig(apiKey: String, defaultModel: String) derives ConfigReader
 
 case class JobConfig(token: String) derives ConfigReader
 

--- a/server/src/main/scala/ru/trett/rss/server/controllers/UserController.scala
+++ b/server/src/main/scala/ru/trett/rss/server/controllers/UserController.scala
@@ -8,7 +8,7 @@ import org.http4s.circe.CirceEntityDecoder.*
 import org.http4s.circe.CirceEntityEncoder.*
 import org.http4s.dsl.io.*
 import org.typelevel.log4cats.{LoggerFactory, SelfAwareStructuredLogger}
-import ru.trett.rss.models.{SummaryLanguage, SummaryModel, UserSettings}
+import ru.trett.rss.models.{SummaryLanguage, SummaryModel, SummaryProvider, UserSettings}
 import ru.trett.rss.server.models.User
 import ru.trett.rss.server.services.UserService
 
@@ -34,14 +34,21 @@ object UserController {
                     validatedLanguage = settings.summaryLanguage.flatMap { lang =>
                         SummaryLanguage.fromString(lang).map(_.displayName)
                     }
+                    validatedProvider = settings.summaryProvider.flatMap { provider =>
+                        SummaryProvider.fromString(provider).map(_.displayName)
+                    }
+                    resolvedProvider = validatedProvider
+                        .flatMap(SummaryProvider.fromString)
+                        .getOrElse(SummaryProvider.default)
                     validatedModel = settings.summaryModel.flatMap { model =>
-                        SummaryModel.fromString(model).map(_.displayName)
+                        SummaryModel.fromString(resolvedProvider, model).map(_.displayName)
                     }
                     updatedUser = user.copy(settings =
                         User.Settings(
                             settings.hideRead,
                             validatedLanguage,
                             settings.aiMode,
+                            validatedProvider,
                             validatedModel
                         )
                     )
@@ -49,6 +56,7 @@ object UserController {
                     _ <- logger.info(s"""User: ${user.email} was updated with settings:
                           |hideRead: ${settings.hideRead},
                           |summaryLanguage: $validatedLanguage,
+                          |summaryProvider: $validatedProvider,
                           |aiMode: ${settings.aiMode},
                           |summaryModel: $validatedModel""".stripMargin)
                     _ <- cacheUpdater(updatedUser)

--- a/server/src/main/scala/ru/trett/rss/server/models/User.scala
+++ b/server/src/main/scala/ru/trett/rss/server/models/User.scala
@@ -17,6 +17,7 @@ object User:
         hideRead: Boolean = false,
         summaryLanguage: Option[String] = None,
         aiMode: Option[Boolean] = None,
+        summaryProvider: Option[String] = None,
         summaryModel: Option[String] = None
     ):
         /** AI mode is the default. Returns true unless aiMode is explicitly set to false. */

--- a/server/src/main/scala/ru/trett/rss/server/services/SummarizeService.scala
+++ b/server/src/main/scala/ru/trett/rss/server/services/SummarizeService.scala
@@ -5,6 +5,7 @@ import fs2.Stream
 import io.circe.Decoder
 import io.circe.Json
 import io.circe.generic.auto.*
+import io.circe.parser.parse
 import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.Method
@@ -16,7 +17,7 @@ import org.http4s.client.Client
 import org.typelevel.ci.*
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.LoggerFactory
-import ru.trett.rss.models.{SummaryLanguage, SummaryModel, SummaryEvent}
+import ru.trett.rss.models.{SummaryEvent, SummaryLanguage, SummaryModel, SummaryProvider}
 import ru.trett.rss.server.models.User
 import ru.trett.rss.server.repositories.FeedRepository
 import org.jsoup.Jsoup
@@ -27,13 +28,20 @@ case class Content(parts: Option[List[Part]])
 case class Candidate(content: Content)
 case class GeminiResponse(candidates: List[Candidate])
 
-class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKey: String)(using
-    loggerFactory: LoggerFactory[IO]
-):
+class SummarizeService(
+    feedRepository: FeedRepository,
+    client: Client[IO],
+    googleApiKey: String,
+    openAiApiKey: String,
+    openAiDefaultModel: String
+)(using loggerFactory: LoggerFactory[IO]):
+
+    private case class ProviderSelection(provider: SummaryProvider, model: SummaryModel)
 
     given Decoder[GeminiResponse] = Decoder.forProduct1("candidates")(GeminiResponse.apply)
     private val logger: Logger[IO] = LoggerFactory[IO].getLogger
     private val batchSize = 30
+    private val openAiEndpoint = Uri.unsafeFromString("https://api.openai.com/v1/chat/completions")
 
     private def getEndpoint(modelId: String, stream: Boolean = false): Uri =
         val method = if stream then "streamGenerateContent" else "generateContent"
@@ -77,17 +85,74 @@ class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKe
                 method = Method.POST,
                 uri = getEndpoint(modelId, stream),
                 headers = Headers(
-                    Header.Raw(ci"X-goog-api-key", apiKey),
+                    Header.Raw(ci"X-goog-api-key", googleApiKey),
                     Header.Raw(ci"Content-Type", "application/json")
                 )
             ).withEntity(config)
         )
 
-    def streamSummary(user: User, offset: Int): Stream[IO, SummaryEvent] =
-        val selectedModel = user.settings.summaryModel
-            .flatMap(SummaryModel.fromString)
-            .getOrElse(SummaryModel.default)
+    private def buildOpenAiRequest(
+        modelId: String,
+        prompt: String,
+        stream: Boolean = false
+    ): IO[Request[IO]] =
+        val body = Json.obj(
+            "model" -> Json.fromString(modelId),
+            "messages" -> Json.arr(
+                Json.obj("role" -> Json.fromString("user"), "content" -> Json.fromString(prompt))
+            ),
+            "stream" -> Json.fromBoolean(stream)
+        )
 
+        IO.pure(
+            Request[IO](
+                method = Method.POST,
+                uri = openAiEndpoint,
+                headers = Headers(
+                    Header.Raw(ci"Authorization", s"Bearer $openAiApiKey"),
+                    Header.Raw(ci"Content-Type", "application/json")
+                )
+            ).withEntity(body)
+        )
+
+    private def resolveSelection(user: User): ProviderSelection =
+        val provider = user.settings.summaryProvider
+            .flatMap(SummaryProvider.fromString)
+            .getOrElse(SummaryProvider.default)
+
+        val model = user.settings.summaryModel
+            .flatMap(SummaryModel.fromString(provider, _))
+            .orElse {
+                if provider == SummaryProvider.OpenAI then
+                    SummaryModel
+                        .fromModelId(openAiDefaultModel)
+                        .filter(_.provider == SummaryProvider.OpenAI)
+                else None
+            }
+            .getOrElse(SummaryModel.defaultFor(provider))
+
+        ProviderSelection(provider, model)
+
+    private def validateProviderKey(provider: SummaryProvider): Option[String] = provider match
+        case SummaryProvider.Gemini if googleApiKey.trim.isEmpty =>
+            Some("Gemini is selected, but GOOGLE_API_KEY is not configured.")
+        case SummaryProvider.OpenAI if openAiApiKey.trim.isEmpty =>
+            Some("OpenAI is selected, but OPENAI_API_KEY is not configured.")
+        case _ => None
+
+    def streamSummary(user: User, offset: Int): Stream[IO, SummaryEvent] =
+        val selection = resolveSelection(user)
+        validateProviderKey(selection.provider) match
+            case Some(error) =>
+                Stream.emit(SummaryEvent.Error(error)) ++ Stream.emit(SummaryEvent.Done)
+            case None =>
+                streamSummaryInternal(user, offset, selection)
+
+    private def streamSummaryInternal(
+        user: User,
+        offset: Int,
+        selection: ProviderSelection
+    ): Stream[IO, SummaryEvent] =
         Stream
             .eval(feedRepository.getTotalUnreadCount(user.id))
             .flatMap { totalUnread =>
@@ -102,7 +167,7 @@ class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKe
                     Stream.emit(metadata) ++ (
                         if feeds.isEmpty && offset == 0 then
                             Stream
-                                .eval(generateFunFact(user, selectedModel.modelId))
+                                .eval(generateFunFact(user, selection))
                                 .map(SummaryEvent.FunFact(_)) ++ Stream.emit(SummaryEvent.Done)
                         else if feeds.isEmpty then Stream.emit(SummaryEvent.Done)
                         else
@@ -117,7 +182,7 @@ class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKe
                                 .drain ++ summarizeStream(
                                 strippedText,
                                 validatedLanguage.displayName,
-                                selectedModel.modelId
+                                selection
                             )
                     )
                 }
@@ -129,7 +194,7 @@ class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKe
                     ) ++ Stream.emit(SummaryEvent.Done)
             }
 
-    private def generateFunFact(user: User, modelId: String): IO[String] =
+    private def generateFunFact(user: User, selection: ProviderSelection): IO[String] =
         val validatedLanguage = user.settings.summaryLanguage
             .flatMap(SummaryLanguage.fromString)
             .getOrElse(SummaryLanguage.English)
@@ -141,38 +206,65 @@ class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKe
                         |Do not use markdown formatting.
                         |Do not add any introduction or preamble, just state the fact directly.""".stripMargin
 
-        buildGeminiRequest(modelId, prompt, temperature = Some(1.5)).flatMap { request =>
-            client
-                .run(request)
-                .use { response =>
-                    if response.status.isSuccess then
-                        response
-                            .as[GeminiResponse]
-                            .map { geminiResp =>
-                                geminiResp.candidates.headOption
-                                    .flatMap(_.content.parts.flatMap(_.headOption))
-                                    .map(_.text.trim)
-                                    .filter(_.nonEmpty)
-                                    .getOrElse("")
+        selection.provider match
+            case SummaryProvider.Gemini =>
+                buildGeminiRequest(selection.model.modelId, prompt, temperature = Some(1.5))
+                    .flatMap { request =>
+                        client
+                            .run(request)
+                            .use { response =>
+                                if response.status.isSuccess then
+                                    response
+                                        .as[GeminiResponse]
+                                        .map { geminiResp =>
+                                            geminiResp.candidates.headOption
+                                                .flatMap(_.content.parts.flatMap(_.headOption))
+                                                .map(_.text.trim)
+                                                .filter(_.nonEmpty)
+                                                .getOrElse("")
+                                        }
+                                else
+                                    response.bodyText.compile.string.flatMap { body =>
+                                        logger.error(
+                                            s"Gemini API error (fun fact): status=${response.status}, body=$body"
+                                        ) *>
+                                            IO.pure("")
+                                    }
                             }
-                    else
-                        response.bodyText.compile.string.flatMap { body =>
-                            logger.error(
-                                s"Gemini API error (fun fact): status=${response.status}, body=$body"
+                            .handleErrorWith { error =>
+                                logger.error(error)(
+                                    s"Error generating Gemini fun fact: ${error.getMessage}"
+                                ) *>
+                                    IO.pure("")
+                            }
+                    }
+            case SummaryProvider.OpenAI =>
+                buildOpenAiRequest(selection.model.modelId, prompt).flatMap { request =>
+                    client
+                        .run(request)
+                        .use { response =>
+                            if response.status.isSuccess then
+                                response.as[Json].map(extractOpenAiMessage)
+                            else
+                                response.bodyText.compile.string.flatMap { body =>
+                                    logger.error(
+                                        s"OpenAI API error (fun fact): status=${response.status}, body=$body"
+                                    ) *>
+                                        IO.pure("")
+                                }
+                        }
+                        .handleErrorWith { error =>
+                            logger.error(error)(
+                                s"Error generating OpenAI fun fact: ${error.getMessage}"
                             ) *>
                                 IO.pure("")
                         }
                 }
-                .handleErrorWith { error =>
-                    logger.error(error)(s"Error generating fun fact: ${error.getMessage}") *>
-                        IO.pure("")
-                }
-        }
 
     private def summarizeStream(
         text: String,
         language: String,
-        modelId: String
+        selection: ProviderSelection
     ): Stream[IO, SummaryEvent] =
         val prompt = s"""You must follow these rules for your response:
                         |1. Provide only the raw text of the code.
@@ -190,38 +282,64 @@ class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKe
                         |13. For each topic, list the key stories with brief summaries.
                         |Now, following these rules exactly summarize the following text. Answer in $language: $text.""".stripMargin
 
-        Stream
-            .eval(buildGeminiRequest(modelId, prompt, stream = true))
-            .flatMap { request =>
-                client.stream(request).flatMap { response =>
-                    if response.status.isSuccess then
-                        response.body
-                            .through(fs2.text.utf8.decode)
-                            .through(io.circe.fs2.stringArrayParser)
-                            .through(io.circe.fs2.decoder[IO, GeminiResponse])
-                            .map { geminiResp =>
-                                geminiResp.candidates.headOption
-                                    .flatMap(_.content.parts.flatMap(_.headOption))
-                                    .map(_.text)
-                                    .getOrElse("")
-                            }
-                            .map { text =>
-                                text.stripPrefix("```html").stripSuffix("```")
-                            }
-                            .filter(_.nonEmpty)
-                            .map(SummaryEvent.Content(_))
-                    else
-                        Stream
-                            .eval(response.bodyText.compile.string.flatMap { body =>
-                                logger.error(
-                                    s"Gemini API stream error: status=${response.status}, body=$body"
+        val stream = selection.provider match
+            case SummaryProvider.Gemini =>
+                Stream
+                    .eval(buildGeminiRequest(selection.model.modelId, prompt, stream = true))
+                    .flatMap { request =>
+                        client.stream(request).flatMap { response =>
+                            if response.status.isSuccess then
+                                response.body
+                                    .through(fs2.text.utf8.decode)
+                                    .through(io.circe.fs2.stringArrayParser)
+                                    .through(io.circe.fs2.decoder[IO, GeminiResponse])
+                                    .map { geminiResp =>
+                                        geminiResp.candidates.headOption
+                                            .flatMap(_.content.parts.flatMap(_.headOption))
+                                            .map(_.text)
+                                            .getOrElse("")
+                                    }
+                                    .map(text => text.stripPrefix("```html").stripSuffix("```"))
+                                    .filter(_.nonEmpty)
+                                    .map(SummaryEvent.Content(_))
+                            else
+                                Stream
+                                    .eval(response.bodyText.compile.string.flatMap { body =>
+                                        logger.error(
+                                            s"Gemini API stream error: status=${response.status}, body=$body"
+                                        )
+                                    })
+                                    .drain ++ Stream.emit(
+                                    SummaryEvent.Error(s"API error: ${response.status.reason}")
                                 )
-                            })
-                            .drain ++ Stream.emit(
-                            SummaryEvent.Error(s"API error: ${response.status.reason}")
-                        )
-                }
-            }
+                        }
+                    }
+            case SummaryProvider.OpenAI =>
+                Stream
+                    .eval(buildOpenAiRequest(selection.model.modelId, prompt, stream = true))
+                    .flatMap { request =>
+                        client.stream(request).flatMap { response =>
+                            if response.status.isSuccess then
+                                response.body
+                                    .through(fs2.text.utf8.decode)
+                                    .through(fs2.text.lines)
+                                    .flatMap(line => Stream.emits(parseOpenAiDelta(line).toList))
+                                    .filter(_.nonEmpty)
+                                    .map(text => SummaryEvent.Content(stripMarkdownFence(text)))
+                            else
+                                Stream
+                                    .eval(response.bodyText.compile.string.flatMap { body =>
+                                        logger.error(
+                                            s"OpenAI API stream error: status=${response.status}, body=$body"
+                                        )
+                                    })
+                                    .drain ++ Stream.emit(
+                                    SummaryEvent.Error(s"API error: ${response.status.reason}")
+                                )
+                        }
+                    }
+
+        stream
             .handleErrorWith { error =>
                 val errorMessage = error match
                     case _: TimeoutException =>
@@ -233,3 +351,35 @@ class SummarizeService(feedRepository: FeedRepository, client: Client[IO], apiKe
                     .drain ++
                     Stream.emit(SummaryEvent.Error(errorMessage))
             } ++ Stream.emit(SummaryEvent.Done)
+
+    private def extractOpenAiMessage(json: Json): String =
+        json.hcursor
+            .downField("choices")
+            .downArray
+            .downField("message")
+            .downField("content")
+            .as[String]
+            .toOption
+            .map(_.trim)
+            .filter(_.nonEmpty)
+            .getOrElse("")
+
+    private def parseOpenAiDelta(line: String): Option[String] =
+        val trimmed = line.trim
+        if !trimmed.startsWith("data:") then None
+        else
+            val payload = trimmed.stripPrefix("data:").trim
+            if payload.isEmpty || payload == "[DONE]" then None
+            else
+                parse(payload).toOption.flatMap { json =>
+                    json.hcursor
+                        .downField("choices")
+                        .downArray
+                        .downField("delta")
+                        .downField("content")
+                        .as[String]
+                        .toOption
+                }
+
+    private def stripMarkdownFence(text: String): String =
+        text.stripPrefix("```html").stripPrefix("```").stripSuffix("```")

--- a/server/src/main/scala/ru/trett/rss/server/services/SummarizeService.scala
+++ b/server/src/main/scala/ru/trett/rss/server/services/SummarizeService.scala
@@ -299,7 +299,7 @@ class SummarizeService(
                                             .map(_.text)
                                             .getOrElse("")
                                     }
-                                    .map(text => text.stripPrefix("```html").stripSuffix("```"))
+                                    .map(stripMarkdownFence)
                                     .filter(_.nonEmpty)
                                     .map(SummaryEvent.Content(_))
                             else

--- a/server/src/main/scala/ru/trett/rss/server/services/UserService.scala
+++ b/server/src/main/scala/ru/trett/rss/server/services/UserService.scala
@@ -30,6 +30,7 @@ class UserService(userRepository: UserRepository)(using loggerFactory: LoggerFac
                         user.settings.hideRead,
                         user.settings.summaryLanguage,
                         user.settings.aiMode,
+                        user.settings.summaryProvider,
                         user.settings.summaryModel
                     )
                 )

--- a/server/src/test/scala/ru/trett/rss/server/models/SummaryModelSpec.scala
+++ b/server/src/test/scala/ru/trett/rss/server/models/SummaryModelSpec.scala
@@ -1,0 +1,29 @@
+package ru.trett.rss.server.models
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import ru.trett.rss.models.{SummaryModel, SummaryProvider}
+
+class SummaryModelSpec extends AnyFunSuite with Matchers:
+
+    test("allFor should return only models for the selected provider") {
+        SummaryModel.allFor(SummaryProvider.Gemini).foreach { model =>
+            model.provider shouldBe SummaryProvider.Gemini
+        }
+
+        SummaryModel.allFor(SummaryProvider.OpenAI).foreach { model =>
+            model.provider shouldBe SummaryProvider.OpenAI
+        }
+    }
+
+    test("fromString should validate models within the selected provider") {
+        SummaryModel.fromString(SummaryProvider.OpenAI, "GPT-5 mini") shouldBe Some(
+            SummaryModel.Gpt5Mini
+        )
+        SummaryModel.fromString(SummaryProvider.OpenAI, "Gemini 2.5 Flash") shouldBe None
+    }
+
+    test("defaultFor should use provider-specific defaults") {
+        SummaryModel.defaultFor(SummaryProvider.Gemini) shouldBe SummaryModel.Gemini3FlashPreview
+        SummaryModel.defaultFor(SummaryProvider.OpenAI) shouldBe SummaryModel.Gpt5Mini
+    }

--- a/server/src/test/scala/ru/trett/rss/server/services/SummarizeServiceSpec.scala
+++ b/server/src/test/scala/ru/trett/rss/server/services/SummarizeServiceSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.noop.NoOpFactory
+import ru.trett.rss.models.SummaryEvent
 import ru.trett.rss.server.models.User
 import ru.trett.rss.server.repositories.FeedRepository
 
@@ -33,9 +34,31 @@ class SummarizeServiceSpec extends AnyFunSuite with Matchers with MockFactory {
             .expects(user, 30, 0) // batchSize is 30, expected offset is 0
             .returning(IO.pure(List.empty))
 
-        val service = new SummarizeService(feedRepository, client, "api-key")
+        val service =
+            new SummarizeService(feedRepository, client, "api-key", "openai-key", "gpt-5-mini")
 
         // Call with offset 30 (simulating "Load More" click)
         service.streamSummary(user, 30).compile.toList.unsafeRunSync()
+    }
+
+    test("streamSummary should fail fast when OpenAI is selected without an API key") {
+        val feedRepository = mock[FeedRepository]
+        val client = mock[Client[IO]]
+        val user = User(
+            "user-id",
+            "User",
+            "user@example.com",
+            User.Settings(summaryProvider = Some("OpenAI"))
+        )
+
+        implicit val loggerFactory: LoggerFactory[IO] = NoOpFactory[IO]
+
+        val service = new SummarizeService(feedRepository, client, "api-key", "", "gpt-5-mini")
+        val events = service.streamSummary(user, 0).compile.toList.unsafeRunSync()
+
+        events shouldBe List(
+            SummaryEvent.Error("OpenAI is selected, but OPENAI_API_KEY is not configured."),
+            SummaryEvent.Done
+        )
     }
 }

--- a/shared/src/main/scala/ru/trett/rss/models/SummaryModel.scala
+++ b/shared/src/main/scala/ru/trett/rss/models/SummaryModel.scala
@@ -1,16 +1,30 @@
 package ru.trett.rss.models
 
-enum SummaryModel(val displayName: String, val modelId: String):
+enum SummaryModel(val displayName: String, val modelId: String, val provider: SummaryProvider):
     case Gemini3FlashPreview
-        extends SummaryModel("Gemini 3 Flash Preview", "gemini-3-flash-preview")
-    case GeminiFlashLatest extends SummaryModel("Gemini Flash Latest", "gemini-flash-latest")
-    case Gemini3ProPreview extends SummaryModel("Gemini 3 Pro Preview", "gemini-3-pro-preview")
-    case Gemini25Pro extends SummaryModel("Gemini 2.5 Pro", "gemini-2.5-pro")
-    case Gemini25Flash extends SummaryModel("Gemini 2.5 Flash", "gemini-2.5-flash")
+        extends SummaryModel(
+            "Gemini 3 Flash Preview",
+            "gemini-3-flash-preview",
+            SummaryProvider.Gemini
+        )
+    case GeminiFlashLatest
+        extends SummaryModel("Gemini Flash Latest", "gemini-flash-latest", SummaryProvider.Gemini)
+    case Gemini3ProPreview
+        extends SummaryModel("Gemini 3 Pro Preview", "gemini-3-pro-preview", SummaryProvider.Gemini)
+    case Gemini25Pro
+        extends SummaryModel("Gemini 2.5 Pro", "gemini-2.5-pro", SummaryProvider.Gemini)
+    case Gemini25Flash
+        extends SummaryModel("Gemini 2.5 Flash", "gemini-2.5-flash", SummaryProvider.Gemini)
+    case Gpt5Mini extends SummaryModel("GPT-5 mini", "gpt-5-mini", SummaryProvider.OpenAI)
+    case Gpt41Mini extends SummaryModel("GPT-4.1 mini", "gpt-4.1-mini", SummaryProvider.OpenAI)
+    case Gpt41 extends SummaryModel("GPT-4.1", "gpt-4.1", SummaryProvider.OpenAI)
 
 object SummaryModel:
     def fromString(s: String): Option[SummaryModel] =
         values.find(_.displayName == s)
+
+    def fromString(provider: SummaryProvider, s: String): Option[SummaryModel] =
+        allFor(provider).find(_.displayName == s)
 
     def fromModelId(s: String): Option[SummaryModel] =
         values.find(_.modelId == s)
@@ -20,13 +34,21 @@ object SummaryModel:
 
     def all: List[SummaryModel] = values.toList
 
-    def default: SummaryModel = Gemini3FlashPreview
+    def allFor(provider: SummaryProvider): List[SummaryModel] =
+        values.filter(_.provider == provider).toList
 
-    /** Determines if a model uses thinkingLevel configuration (Gemini 3.x models) */
+    def default: SummaryModel = defaultFor(SummaryProvider.default)
+
+    def defaultFor(provider: SummaryProvider): SummaryModel = provider match
+        case SummaryProvider.Gemini => Gemini3FlashPreview
+        case SummaryProvider.OpenAI => Gpt5Mini
+
+    /** Determines if a Gemini model uses thinkingLevel configuration (Gemini 3.x models) */
     def usesThinkingLevel(modelId: String): Boolean =
         modelId.contains("gemini-3")
 
-    /** Determines if a model uses thinkingBudget configuration (Gemini 2.5 models and flash-latest)
+    /** Determines if a Gemini model uses thinkingBudget configuration (Gemini 2.5 models and
+      * flash-latest)
       */
     def usesThinkingBudget(modelId: String): Boolean =
         modelId.contains("2.5") || modelId.contains("flash-latest")

--- a/shared/src/main/scala/ru/trett/rss/models/SummaryProvider.scala
+++ b/shared/src/main/scala/ru/trett/rss/models/SummaryProvider.scala
@@ -1,0 +1,16 @@
+package ru.trett.rss.models
+
+enum SummaryProvider(val displayName: String):
+    case Gemini extends SummaryProvider("Gemini")
+    case OpenAI extends SummaryProvider("OpenAI")
+
+object SummaryProvider:
+    def fromString(s: String): Option[SummaryProvider] =
+        values.find(_.displayName == s)
+
+    def isValid(s: String): Boolean =
+        fromString(s).isDefined
+
+    def all: List[SummaryProvider] = values.toList
+
+    def default: SummaryProvider = Gemini

--- a/shared/src/main/scala/ru/trett/rss/models/UserSettings.scala
+++ b/shared/src/main/scala/ru/trett/rss/models/UserSettings.scala
@@ -5,6 +5,7 @@ final case class UserSettings(
     hideRead: Boolean,
     summaryLanguage: Option[String],
     aiMode: Option[Boolean] = None,
+    summaryProvider: Option[String] = None,
     summaryModel: Option[String] = None
 ):
     /** AI mode is the default. Returns true unless aiMode is explicitly set to false. */


### PR DESCRIPTION
## Summary
- add OpenAI as a feed-summary provider alongside the existing Gemini integration
- make summary provider and model selectable in user settings and validate provider/model pairs on the server
- keep the existing `/api/summarize` SSE contract intact while adding OpenAI request, streaming, and config support

## Why
The summary feature was hard-wired to Gemini through config, model selection, and request handling. This change adds OpenAI support without changing the frontend summary protocol or removing Gemini.

## User impact
Users can now choose `Gemini` or `OpenAI` in settings and then select a provider-specific model. If OpenAI is selected without `OPENAI_API_KEY` configured, the app returns a clean summary error instead of failing deeper in the request path.

## Validation
- `sbt test`
- `sbt scalafixAll`
- `sbt scalafmtAll`
- `sbt test`

## Notes
- `client/package-lock.json` had a pre-existing unrelated change and was intentionally excluded from this PR.