### PR TITLE
fix: remove blue focus border on feed list items

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -44,7 +44,8 @@
     --_ui5-v2-1-0_shellbar_button_focused_border: 0px transparent none;
 }
 
-.cards {
+.cards,
+.main-content {
     --_ui5-v2-1-0_card_border-radius: 0px 0px 2px 2px;
     --_ui5-v2-1-0_card_header_focus_border: 0px;
     --sapContent_FocusWidth: 0px;


### PR DESCRIPTION
## Summary
- Extended `.main-content` CSS class to include UI5 focus-suppression variables (`--sapContent_FocusWidth: 0px`, `--sapContent_FocusStyle: none`) that were previously only applied to `.cards`
- Removes the blue selection/focus border that appeared around article cards when clicking a feed item on the home page

## Test plan
- [ ] Click a feed item on the home page — no blue border should appear around the card
- [ ] CI passes