### PR TITLE
fix: preserve user read status during importance scoring

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -44,7 +44,8 @@
     --_ui5-v2-1-0_shellbar_button_focused_border: 0px transparent none;
 }
 
-.cards {
+.cards,
+.main-content {
     --_ui5-v2-1-0_card_border-radius: 0px 0px 2px 2px;
     --_ui5-v2-1-0_card_header_focus_border: 0px;
     --sapContent_FocusWidth: 0px;

--- a/server/src/main/scala/ru/trett/rss/server/repositories/FeedRepository.scala
+++ b/server/src/main/scala/ru/trett/rss/server/repositories/FeedRepository.scala
@@ -49,7 +49,10 @@ class FeedRepository(xa: Transactor[IO]):
     def updateFeedImportance(feeds: List[Feed]): IO[Int] =
         if feeds.isEmpty then IO.pure(0)
         else
+            // Use (? OR read) so that a user's manual mark-as-read is never overwritten:
+            // - isRead=true (not important → auto-read): (true OR read) = true  ✓
+            // - isRead=false (important → keep unread): (false OR read) = read  ✓
             Update[(Boolean, Boolean, String, String)](
-                "UPDATE feeds SET important = ?, read = ? WHERE link = ? AND user_id = ?"
+                "UPDATE feeds SET important = ?, read = (? OR read) WHERE link = ? AND user_id = ?"
             ).updateMany(feeds.map(f => (f.important, f.isRead, f.link, f.userId)))
                 .transact(xa)

--- a/server/src/main/scala/ru/trett/rss/server/services/ChannelService.scala
+++ b/server/src/main/scala/ru/trett/rss/server/services/ChannelService.scala
@@ -83,12 +83,20 @@ class ChannelService(
             // Step 2: score new unread feeds and update the DB (separate step, inserts are already safe)
             _ <-
                 if allNewFeeds.nonEmpty then
-                    importanceService
-                        .score(user, highlightedIds, allNewFeeds)
-                        .flatMap(feedRepository.updateFeedImportance)
-                        .handleErrorWith(e =>
-                            logger.warn(s"[Importance] Scoring step failed: ${e.getMessage}")
-                        )
+                    logger.info(s"[Importance] Scoring ${allNewFeeds.size} new feeds") *>
+                        importanceService
+                            .score(user, highlightedIds, allNewFeeds)
+                            .flatTap(scored =>
+                                val important = scored.count(_.important)
+                                val autoRead  = scored.count(f => f.isRead && !f.important)
+                                logger.info(
+                                    s"[Importance] Result: $important important, $autoRead auto-read, ${scored.size - important - autoRead} unclassified"
+                                )
+                            )
+                            .flatMap(feedRepository.updateFeedImportance)
+                            .handleErrorWith(e =>
+                                logger.warn(s"[Importance] Scoring step failed: ${e.getMessage}")
+                            )
                 else IO.unit
         } yield channelResults.map(_._1)
 


### PR DESCRIPTION
## Summary
- Fix \`updateFeedImportance\` SQL to use \`(? OR read)\` so a user's manual mark-as-read is never overwritten by the importance scorer
- Extend focus-border CSS fix to \`.main-content\` in addition to \`.cards\`
- Add structured logging around the importance scoring step (count of important / auto-read / unclassified)

## Test plan
- [ ] CI passes
- [ ] Manually mark a feed item as read, trigger a refresh — item stays read
- [ ] Important items remain unread after scoring