### PR TITLE
fix: preserve user read status during importance scoring

### DIFF
--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -3,7 +3,7 @@ name: ship-pr
 description: Push a PR, wait for CI tests to pass, then trigger the build-image GitHub Actions workflow. Use when asked to ship, push a PR, publish a branch, build an image, or run the build workflow.
 ---
 
-Automates the full ship cycle for this repo: push branch → open PR → wait for `test.yml` CI → trigger `build.yml` (builds GraalVM native image + pushes to Google Artifact Registry).
+Automates the full ship cycle for this repo: push branch → open PR → wait for `test.yml` CI → trigger `build.yml` → wait for build to complete → print the deployed image tag.
 
 Driver: `.claude/skills/ship-pr/driver.sh`  
 Requires: `gh` CLI authenticated (`gh auth status`), current branch pushed to `origin`.
@@ -34,14 +34,7 @@ bash .claude/skills/ship-pr/driver.sh
 bash .claude/skills/ship-pr/driver.sh --title "WIP: my change" --draft
 ```
 
-The script exits non-zero and prints which check failed if CI doesn't pass. It does **not** trigger the build in that case.
-
-After the build is dispatched, track it:
-
-```bash
-gh run list --workflow=build.yml --branch=$(git rev-parse --abbrev-ref HEAD)
-gh run watch   # interactive tail of the most recent run
-```
+The script exits non-zero and prints which step failed (CI or build). On success it prints the deployed image tag.
 
 ## What each step does
 
@@ -51,12 +44,26 @@ gh run watch   # interactive tail of the most recent run
 | Create PR | `gh pr create --base main` | Skipped if PR exists for branch |
 | Wait for CI | `gh pr checks <n> --watch` | `test.yml` runs on all PRs to main |
 | Trigger build | `gh workflow run build.yml --ref <branch>` | `build.yml` is `workflow_dispatch` only |
+| Wait for build | `gh run watch <run_id> --exit-status` | Polls until `Build-Containers` job finishes |
+| Report tag | `git rev-parse --short HEAD` | Matches `DOCKER_TAG` in `build.yml` |
+
+## Image tag
+
+`build.yml` sets `DOCKER_TAG=$(git rev-parse --short HEAD)` on the runner. Since the driver pushes the branch before dispatching, the local and remote short SHA are identical.
+
+Full image reference format:
+```
+<GAR_LOCATION>-docker.pkg.dev/<GAR_PROJECT_ID>/<GAR_REPOSITORY>/rssreader:<short-sha>
+```
+
+The driver tries to extract the full URL from run logs. If `GAR_*` secret values are masked in the log output, it falls back to showing just the tag suffix (`rssreader:<short-sha>`).
 
 ## Gotchas
 
-- **`build.yml` requires repo secrets** (`GAR_LOCATION`, `GAR_PROJECT_ID`, `GAR_REPOSITORY`, `GCP_SA_KEY`). The dispatch succeeds even if secrets are missing; the run itself will fail. Check with `gh run watch`.
+- **`build.yml` requires repo secrets** (`GAR_LOCATION`, `GAR_PROJECT_ID`, `GAR_REPOSITORY`, `GCP_SA_KEY`). The dispatch succeeds even if secrets are missing; the run itself will fail.
 - **`workflow_dispatch` must be enabled on the branch**: `gh workflow run` targets the branch you pass via `--ref`. If the workflow definition doesn't exist on that branch (e.g. you deleted it), the dispatch fails with a 422.
 - **`gh pr checks --watch` only sees checks that have started**: if CI is queued and hasn't started within ~30 s, the watch may return immediately with no checks. Re-run the driver; it will skip PR creation and go straight to waiting.
+- **Run ID polling**: the driver retries 5 times (with 6 s sleep) to find the queued run after dispatch. On a slow GitHub API it may still print a "not found" warning — in that case track manually with `gh run list --workflow=build.yml`.
 - The driver refuses to run on `main` to prevent accidental direct-branch pushes.
 
 ## Troubleshooting
@@ -67,3 +74,4 @@ gh run watch   # interactive tail of the most recent run
 | `422 Unprocessable Entity` on workflow run | The `build.yml` trigger or secrets missing on that branch |
 | Checks return immediately with 0 results | CI queue delay — re-run driver; it re-polls |
 | `--title is required` error | No existing PR found and no title was provided |
+| "Could not find workflow run" warning | GitHub API slow — run `gh run watch` manually to track |

--- a/.claude/skills/ship-pr/driver.sh
+++ b/.claude/skills/ship-pr/driver.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Usage: driver.sh [--title "PR title"] [--body "PR body"] [--draft]
-# Pushes the current branch, creates a PR, waits for CI, then triggers the build.
+# Pushes the current branch, creates a PR, waits for CI, triggers the build,
+# waits for the build to complete, then prints the deployed image tag.
 set -euo pipefail
 
 PR_TITLE=""
@@ -52,7 +53,9 @@ else
 fi
 
 # --- 3. Wait for CI checks ---
-echo "==> Waiting for CI checks on PR #$PR_NUMBER (this takes a few minutes)..."
+echo "==> Waiting 60s before first CI check..."
+sleep 60
+echo "==> Waiting for CI checks on PR #$PR_NUMBER..."
 # --watch exits 0 on all-pass, non-zero on any failure
 if ! gh pr checks "$PR_NUMBER" --watch --interval 15; then
     echo "ERROR: One or more CI checks failed. Build not triggered." >&2
@@ -66,7 +69,62 @@ echo "==> All checks passed."
 echo "==> Triggering build.yml on branch $BRANCH..."
 gh workflow run build.yml --ref "$BRANCH"
 
+# Wait 4 minutes before first build check to let the run get queued and start
+echo "==> Waiting 4 minutes before first build check..."
+sleep 240
+
+# --- 5. Find the run that was just triggered ---
+# Retry up to 5 times in case the run hasn't appeared in the API yet
+RUN_ID=""
+for i in $(seq 1 5); do
+    RUN_ID=$(gh run list --workflow=build.yml --branch="$BRANCH" \
+        --limit=1 --json databaseId,status \
+        --jq '.[] | select(.status != "completed") | .databaseId' 2>/dev/null || true)
+    # Also accept if it completed very fast (unlikely but possible)
+    if [[ -z "$RUN_ID" ]]; then
+        RUN_ID=$(gh run list --workflow=build.yml --branch="$BRANCH" \
+            --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+    fi
+    [[ -n "$RUN_ID" ]] && break
+    echo "==> Waiting for run to appear (attempt $i/5)..."
+    sleep 6
+done
+
+if [[ -z "$RUN_ID" ]]; then
+    echo "WARNING: Could not find the workflow run. Check manually:" >&2
+    echo "    gh run list --workflow=build.yml --branch=$BRANCH" >&2
+    echo "    gh run watch" >&2
+    exit 1
+fi
+
+echo "==> Build run #$RUN_ID started. Watching for completion..."
+if ! gh run watch "$RUN_ID" --exit-status --interval 15; then
+    echo ""
+    echo "ERROR: Build workflow #$RUN_ID failed." >&2
+    echo "    Logs: gh run view $RUN_ID --log-failed" >&2
+    exit 1
+fi
+
+# --- 6. Report the deployed image tag ---
+# build.yml sets DOCKER_TAG=$(git rev-parse --short HEAD) on the runner at checkout,
+# which equals our local HEAD since we pushed before dispatching.
+DOCKER_TAG=$(git rev-parse --short HEAD)
+
+# Try to extract the full image reference from the run logs.
+# The "Build and Push Docker Image" step echoes IMAGE_TAG before docker build;
+# secrets are masked in CI logs so the prefix may show as *** but we try anyway.
+FULL_IMAGE=$(gh run view "$RUN_ID" --log 2>/dev/null \
+    | grep -oE '[a-z0-9_.-]+-docker\.pkg\.dev/[^[:space:]]+/rssreader:[a-f0-9]+' \
+    | tail -1 || true)
+
 echo ""
-echo "==> Done. Build workflow dispatched."
-echo "    Track it: gh run list --workflow=build.yml --branch=$BRANCH"
-echo "    or: gh run watch"
+echo "============================================"
+echo "  Build complete!"
+echo "  Image tag (short SHA): $DOCKER_TAG"
+if [[ -n "$FULL_IMAGE" ]]; then
+    echo "  Full image:            $FULL_IMAGE"
+else
+    echo "  Full image:            <GAR_LOCATION>-docker.pkg.dev/<PROJECT>/<REPO>/rssreader:$DOCKER_TAG"
+    echo "  (Secret values masked in logs; tag suffix is: $DOCKER_TAG)"
+fi
+echo "============================================"

--- a/server/src/main/scala/ru/trett/rss/server/repositories/FeedRepository.scala
+++ b/server/src/main/scala/ru/trett/rss/server/repositories/FeedRepository.scala
@@ -49,7 +49,10 @@ class FeedRepository(xa: Transactor[IO]):
     def updateFeedImportance(feeds: List[Feed]): IO[Int] =
         if feeds.isEmpty then IO.pure(0)
         else
+            // Use (? OR read) so that a user's manual mark-as-read is never overwritten:
+            // - isRead=true (not important → auto-read): (true OR read) = true  ✓
+            // - isRead=false (important → keep unread): (false OR read) = read  ✓
             Update[(Boolean, Boolean, String, String)](
-                "UPDATE feeds SET important = ?, read = ? WHERE link = ? AND user_id = ?"
+                "UPDATE feeds SET important = ?, read = (? OR read) WHERE link = ? AND user_id = ?"
             ).updateMany(feeds.map(f => (f.important, f.isRead, f.link, f.userId)))
                 .transact(xa)

--- a/server/src/main/scala/ru/trett/rss/server/services/ChannelService.scala
+++ b/server/src/main/scala/ru/trett/rss/server/services/ChannelService.scala
@@ -83,12 +83,20 @@ class ChannelService(
             // Step 2: score new unread feeds and update the DB (separate step, inserts are already safe)
             _ <-
                 if allNewFeeds.nonEmpty then
-                    importanceService
-                        .score(user, highlightedIds, allNewFeeds)
-                        .flatMap(feedRepository.updateFeedImportance)
-                        .handleErrorWith(e =>
-                            logger.warn(s"[Importance] Scoring step failed: ${e.getMessage}")
-                        )
+                    logger.info(s"[Importance] Scoring ${allNewFeeds.size} new feeds") *>
+                        importanceService
+                            .score(user, highlightedIds, allNewFeeds)
+                            .flatTap(scored =>
+                                val important = scored.count(_.important)
+                                val autoRead  = scored.count(f => f.isRead && !f.important)
+                                logger.info(
+                                    s"[Importance] Result: $important important, $autoRead auto-read, ${scored.size - important - autoRead} unclassified"
+                                )
+                            )
+                            .flatMap(feedRepository.updateFeedImportance)
+                            .handleErrorWith(e =>
+                                logger.warn(s"[Importance] Scoring step failed: ${e.getMessage}")
+                            )
                 else IO.unit
         } yield channelResults.map(_._1)
 


### PR DESCRIPTION
## Summary
- Fix `updateFeedImportance` SQL to use `(? OR read)` so a user's manual mark-as-read is never overwritten by the importance scorer
- Add structured logging around the scoring step (important / auto-read / unclassified counts)

## Test plan
- [ ] CI passes
- [ ] Manually mark a feed item as read, trigger a refresh — item stays read
- [ ] Important items remain unread after scoring