### PR TITLE
fix: send description instead of title to Gemini scoring

### DIFF
--- a/server/src/main/scala/ru/trett/rss/server/services/ChannelService.scala
+++ b/server/src/main/scala/ru/trett/rss/server/services/ChannelService.scala
@@ -88,7 +88,7 @@ class ChannelService(
                             .score(user, highlightedIds, allNewFeeds)
                             .flatTap(scored =>
                                 val important = scored.count(_.important)
-                                val autoRead  = scored.count(f => f.isRead && !f.important)
+                                val autoRead = scored.count(f => f.isRead && !f.important)
                                 logger.info(
                                     s"[Importance] Result: $important important, $autoRead auto-read, ${scored.size - important - autoRead} unclassified"
                                 )

--- a/server/src/main/scala/ru/trett/rss/server/services/ImportanceService.scala
+++ b/server/src/main/scala/ru/trett/rss/server/services/ImportanceService.scala
@@ -111,17 +111,23 @@ class ImportanceService(client: Client[IO])(using loggerFactory: LoggerFactory[I
                         ) *> IO.pure(batch.map(_.copy(important = false, isRead = true)))
                     }
 
+    private val maxDescriptionLength = 500
+
     private def buildBatchPrompt(batch: List[Feed], bannedCategories: List[String]): String =
         val items = batch.zipWithIndex
             .map { case (f, i) =>
-                s"${i + 1}. Title: \"${f.title}\" | Categories: \"${f.categories.mkString(", ")}\""
+                val desc =
+                    if f.description.length > maxDescriptionLength
+                    then f.description.take(maxDescriptionLength) + "…"
+                    else f.description
+                s"${i + 1}. Title: \"${f.title}\" | Description: \"$desc\" | Categories: \"${f.categories.mkString(", ")}\""
             }
             .mkString("\n")
         val bannedNote =
             if bannedCategories.nonEmpty then
                 s"""
                    |
-                   |Always answer "no" for any item whose title or categories are related to: ${bannedCategories
+                   |Always answer "no" for any item whose title, description, or categories are related to: ${bannedCategories
                       .mkString(", ")}.
                    |""".stripMargin
             else ""


### PR DESCRIPTION
## Summary
- ImportanceService now sends article description (truncated to 500 chars) instead of just the title to Gemini for importance scoring
- Descriptions longer than 500 characters are cut with an ellipsis to avoid overwhelming the Gemini API
- Banned-categories prompt text updated to also mention description

## Test plan
- [ ] CI passes
- [ ] Gemini scoring uses description content for classification